### PR TITLE
调用未定义的变量会产生 Notice 级别的错误

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -114,6 +114,10 @@ class Copyright_Plugin implements Typecho_Plugin_Interface {
     }
 
     private static function superAdd($content, $widget) {
+        $t_author = "";
+        $t_url = "";
+        $t_notice  = "";
+	    
     	if (isset($widget->fields->author)) {
     		$author = $widget->fields->author;
             if($author) {


### PR DESCRIPTION
当部分设置没有被启用时，直接调用未定义的变量会产生 Notice 级别的错误